### PR TITLE
Fix project update

### DIFF
--- a/dev/app/components/main/project-form/project-form.controller.js
+++ b/dev/app/components/main/project-form/project-form.controller.js
@@ -65,6 +65,8 @@ function ProjectFormController ($rootScope, $state, $stateParams,
     }
 
     function updateProject () {
+        if(vm.project.SectionIds.length === 0)
+            vm.project.SectionIds = [0];
         projects.updateProject(editId, vm.project, 
             updateSuccess, updateFailure);
     }


### PR DESCRIPTION
Ya no tira el error de ModelState. Ese error lo tiraba por que no permitía editar un proyecto mandandole una lista vacía de secciones asociadas.